### PR TITLE
Use the Pex CLI instead of the API.

### DIFF
--- a/pants_jupyter_plugin/cache.py
+++ b/pants_jupyter_plugin/cache.py
@@ -1,0 +1,8 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from pathlib import Path
+
+import xdg
+
+DIR = Path(xdg.xdg_cache_home()) / "pants_jupyter_plugin"

--- a/pants_jupyter_plugin/download.py
+++ b/pants_jupyter_plugin/download.py
@@ -1,0 +1,35 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import io
+from pathlib import Path
+from typing import Callable
+from uuid import uuid4
+
+import requests
+
+from pants_jupyter_plugin.lock import creation_lock
+
+
+class DownloadError(Exception):
+    """Indicates an error downloading a file."""
+
+
+def download_once(
+    url: str, path: Path, post_process: Callable[[Path], None] = lambda _: None
+) -> None:
+    """Donloads a file from the given url to the given path exactly once.
+
+    If a post_process function is given, it's passed the path of the temporary download file to
+    inspect or post-process in any way seen fit except moving the file.
+    """
+    with creation_lock(path) as locked:
+        if locked:
+            download_to = path.parent / f"{path.name}.{uuid4().hex}"
+            with requests.get(url=url, stream=True) as response, download_to.open(mode="wb") as fp:
+                if not response.ok:
+                    raise DownloadError(f"GET of {url} returned {response.status_code}.")
+                for chunk in response.iter_content(chunk_size=io.DEFAULT_BUFFER_SIZE):
+                    fp.write(chunk)
+            post_process(download_to)
+            download_to.rename(path)

--- a/pants_jupyter_plugin/lock.py
+++ b/pants_jupyter_plugin/lock.py
@@ -1,0 +1,27 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+
+from filelock import FileLock
+
+
+@contextmanager
+def creation_lock(path: Path) -> Iterator[Optional[str]]:
+    """A context manager that yields a creation lock if the given path does not exist.
+
+    The lock should be considered an opaque token. If its not None, the file does not exist and the
+    lock to create the file has been acquired. If it is None, the file was already created.
+
+    This is a blocking lock but otherwise safe lock.
+    """
+    if path.exists():
+        yield None
+        return
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = f"{path}.lock"
+    with FileLock(lock_file):
+        yield None if path.exists() else lock_file

--- a/pants_jupyter_plugin/pex.py
+++ b/pants_jupyter_plugin/pex.py
@@ -29,6 +29,7 @@ class Pex:
 
         The PEX file will be sanity checked to at least be a zip file and made executable.
         """
+
         def activate_pex(path: Path) -> None:
             if not zipfile.is_zipfile(path):
                 raise DownloadError(

--- a/pants_jupyter_plugin/pex.py
+++ b/pants_jupyter_plugin/pex.py
@@ -1,0 +1,100 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import hashlib
+import os
+import subprocess
+import sys
+import zipfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterator, List, Optional
+
+from pants_jupyter_plugin import cache
+from pants_jupyter_plugin.download import DownloadError, download_once
+from pants_jupyter_plugin.lock import creation_lock
+
+
+@dataclass(frozen=True)
+class Pex:
+    DEFAULT_VERSION = "2.1.32"
+    _CACHE = cache.DIR / "pex"
+
+    exe: Path
+    mounted: List[Path] = field(default_factory=list)
+
+    @staticmethod
+    def download_once(url: str, download_to: Path) -> None:
+        """Downloads a PEX file once.
+
+        The PEX file will be sanity checked to at least be a zip file and made executable.
+        """
+        def activate_pex(path: Path) -> None:
+            if not zipfile.is_zipfile(path):
+                raise DownloadError(
+                    f"The PEX at {url} was downloaded to {path} but it does not appear to be a "
+                    "valid zip file."
+                )
+            path.chmod(0o755)
+
+        download_once(url, download_to, post_process=activate_pex)
+
+    @classmethod
+    def load(cls, version: Optional[str] = None) -> "Pex":
+        pex_version = version or cls.DEFAULT_VERSION
+        url = f"https://github.com/pantsbuild/pex/releases/download/v{pex_version}/pex"
+        pex_exe = cls._CACHE / "exes" / f"pex-{pex_version}.pex"
+        cls.download_once(url, pex_exe)
+        return cls(exe=pex_exe)
+
+    def unmount(self) -> Iterator[Path]:
+        """Scrubs sys.path and sys.modules of any contents from previously mounted PEXes.
+
+        WARNING: This will irreversibly mutate sys.path and sys.modules each time it's called.
+        """
+        while self.mounted:
+            pex_sys_path_entry = self.mounted.pop()
+            sys.path[:] = [
+                entry
+                for entry in sys.path
+                if entry and os.path.exists(entry) and not pex_sys_path_entry.samefile(entry)
+            ]
+            for name, module in list(sys.modules.items()):
+                module_path = getattr(module, "__file__", None)
+                if module_path is not None:
+                    if pex_sys_path_entry in Path(module_path).parents:
+                        del sys.modules[name]
+            yield pex_sys_path_entry
+
+    def mount_pex(self, pex_to_mount: Path) -> Iterator[Path]:
+        """Mounts the contents of the given PEX on the sys.path for importing."""
+        venv = (
+            self._CACHE
+            / "venvs"
+            / hashlib.sha1(pex_to_mount.read_bytes()).hexdigest()
+            / pex_to_mount.name
+        )
+        with creation_lock(venv) as locked:
+            if locked:
+                env = os.environ.copy()
+                env.update(PEX_INTERPRETER="1")
+                subprocess.run(
+                    args=[str(self.exe), "-m", "pex.tools", str(pex_to_mount), "venv", str(venv)],
+                    env=env,
+                    check=True,
+                )
+        python = venv / "bin" / "python"
+        result = subprocess.run(
+            args=[
+                str(python),
+                "-c",
+                "import os, site; print(os.linesep.join(site.getsitepackages()))",
+            ],
+            stdout=subprocess.PIPE,
+            check=True,
+        )
+        for path in result.stdout.decode().splitlines():
+            path_entry = Path(path)
+            sys.path.append(path)
+            self.mounted.append(path_entry)
+            yield path_entry

--- a/pants_jupyter_plugin/plugin.py
+++ b/pants_jupyter_plugin/plugin.py
@@ -17,9 +17,10 @@ import ipywidgets
 import nest_asyncio
 from IPython.core.magic import Magics, line_magic, magics_class
 from IPython.display import Javascript, display
-from twitter.common.contextutil import environment_as, temporary_dir
 
 # TODO: replace or vendor these.
+from twitter.common.contextutil import environment_as, temporary_dir
+
 from pants_jupyter_plugin.pex import Pex
 
 FAIL_GLYPH = "✗"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,13 @@ classifiers = [
 requires-python = ">=3.6,<3.10"
 requires = [
   "dataclasses==0.8; python_version == '3.6'",
+  "filelock==3.0.12",
   "ipython==7.16.1",
   "ipywidgets==7.6.3",
   "nest_asyncio==1.5.1",
-  "pex==2.1.32",
+  "requests==2.25.1",
   "twitter.common.contextutil==0.3.11",
+  "xdg==5.0.1",
 ]
 
 [tool.flit.sdist]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,18 +1,20 @@
 # Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
-import io
 import shutil
-import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
-from uuid import uuid4
 
 import pytest
-import requests
 from _pytest.tmpdir import TempPathFactory
-from filelock import FileLock
+
+from pants_jupyter_plugin.pex import Pex
+
+
+@pytest.fixture
+def pex() -> Pex:
+    return Pex.load()
 
 
 @dataclass(frozen=True)
@@ -36,31 +38,12 @@ class PantsRepo:
 
     @classmethod
     def create(cls, build_root: Path, pants_release: PantsRelease) -> "PantsRepo":
+        url = (
+            "https://github.com/pantsbuild/pants/releases/download/"
+            f"release_{pants_release.version}/{pants_release.pex}"
+        )
         pants_exe = Path(".pants_versions") / f"pants.{pants_release.version}.pex"
-
-        # We use the recipe here to ensure just 1 download happens across xdist workers if xdist is in
-        # play: https://github.com/pytest-dev/pytest-xdist/blob/1189ae4b91c8eb2a4c81a87775a3807f9e253c68/README.rst#making-session-scoped-fixtures-execute-only-once
-        if not pants_exe.exists():
-            pants_exe.parent.mkdir(parents=False, exist_ok=True)
-            with FileLock(f"{pants_exe}.lock"):
-                if not pants_exe.exists():
-                    url = (
-                        "https://github.com/pantsbuild/pants/releases/download/"
-                        f"release_{pants_release.version}/{pants_release.pex}"
-                    )
-                    download_to = pants_exe.parent / f"{pants_exe.name}.{uuid4().hex}"
-                    with requests.get(url=url, stream=True) as response, download_to.open(
-                        mode="wb"
-                    ) as fp:
-                        assert response.ok, f"GET of {url} returned {response.status_code}."
-                        for chunk in response.iter_content(chunk_size=io.DEFAULT_BUFFER_SIZE):
-                            fp.write(chunk)
-                    assert zipfile.is_zipfile(download_to), (
-                        f"The Pants PEX at {url} was downloaded to {download_to} but it does not "
-                        "appear to be a valid zip file."
-                    )
-                    download_to.chmod(0o755)
-                    download_to.rename(pants_exe)
+        Pex.download_once(url, pants_exe)
 
         pants = build_root / "pants"
         shutil.copy(pants_exe, pants)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -5,13 +5,14 @@ import subprocess
 from pathlib import Path
 from textwrap import dedent
 
-import pytest
 from conftest import PantsRepo
 
+from pants_jupyter_plugin.pex import Pex
 
-def test_pex_load(tmpdir: Path) -> None:
+
+def test_pex_load(pex: Pex, tmpdir: Path) -> None:
     pex_file = tmpdir / "colors.pex"
-    subprocess.run(["pex", "ansicolors==1.1.8", "-o", pex_file], check=True)
+    subprocess.run([str(pex.exe), "ansicolors==1.1.8", "-o", pex_file], check=True)
     subprocess.run(
         [
             "ipython",

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,14 @@ envlist =
 
 [testenv]
 deps =
-  dataclasses==0.8; python_version == '3.6'
-  filelock==3.0.12
   ipdb==0.13.5
   Pygments==2.8.0
   pytest==6.2.2
   pytest-icdiff==0.5
   pytest-xdist==2.2.1
-  requests==2.25.1
+passenv =
+  # This is used for xdg calculation of our cache dir.
+  HOME
 commands =
   pytest {posargs:-vvs}
 


### PR DESCRIPTION
This is both more robust and more flexible. Now Pants and Pex are fully
decoupled from the notebook session interpreter.

Fixes #8
Fixes #9