### PR TITLE
Ensure PEXes are compatible with `sys.executable`.

### DIFF
--- a/pants_jupyter_plugin/env.py
+++ b/pants_jupyter_plugin/env.py
@@ -8,7 +8,7 @@ from typing import Any, Mapping
 def create(**env_vars: Any) -> Mapping[str, str]:
     """Creates a copy of the current environment with the specified alterations.
 
-    Keyword parameters with non-`None` values are added to the environment with the enviornment
+    Keyword parameters with non-`None` values are added to the environment with the environment
     variable value being taken from the str representation of the value. Keyword parameters with
     `None` values are removed from the environment.
     """

--- a/pants_jupyter_plugin/env.py
+++ b/pants_jupyter_plugin/env.py
@@ -1,0 +1,21 @@
+# Copyright 2021 Pants project contributors (see CONTRIBUTORS.md).
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+
+import os
+from typing import Any, Mapping
+
+
+def create(**env_vars: Any) -> Mapping[str, str]:
+    """Creates a copy of the current environment with the specified alterations.
+
+    Keyword parameters with non-`None` values are added to the environment with the enviornment
+    variable value being taken from the str representation of the value. Keyword parameters with
+    `None` values are removed from the environment.
+    """
+    env = os.environ.copy()
+    for name, value in env_vars.items():
+        if value is not None:
+            env[name] = str(value)
+        else:
+            env.pop(name, None)
+    return env

--- a/pants_jupyter_plugin/pex.py
+++ b/pants_jupyter_plugin/pex.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from textwrap import dedent
 from typing import Any, Iterable, Iterator, List, Optional, Sequence
+from uuid import uuid4
 
 from pants_jupyter_plugin import cache, env
 from pants_jupyter_plugin.download import DownloadError, download_once
@@ -146,7 +147,9 @@ class Pex:
                         interpreter_constraints=interpreter_constraints,
                         compatible_interpreters=compatible_interpreters,
                     )
-                run_pex_tool(args=["venv", str(venv)])
+                venv_tmp = venv.parent / f"{venv.name}.{uuid4().hex}"
+                run_pex_tool(args=["venv", str(venv_tmp)])
+                venv_tmp.rename(venv)
 
         python = venv / "bin" / "python"
         result = subprocess.run(

--- a/pants_jupyter_plugin/plugin.py
+++ b/pants_jupyter_plugin/plugin.py
@@ -239,7 +239,10 @@ class _PexEnvironmentBootstrapper(Magics):  # type: ignore[misc]  # IPython.core
             title = f"[Resolve] {requirements}"
             safe_requirements = " ".join(shlex.quote(r) for r in shlex.split(requirements))
             # TODO: Add support for toggling `--no-pypi` and find-links/index configs.
-            cmd = f'{self._pex.exe} -vv -o "{output_pex}" {safe_requirements}'
+            cmd = (
+                f'{self._pex.exe} -vv --python {sys.executable} -o "{output_pex}" '
+                f"{safe_requirements}"
+            )
             return self._stream_binary_build_with_output(cmd, title, tmp_path, extension="pex")
 
     def _run_pants(
@@ -291,7 +294,7 @@ class _PexEnvironmentBootstrapper(Magics):  # type: ignore[misc]  # IPython.core
                     )
 
                     # Bootstrap pex.
-                    for path in self._pex.mount_pex(pex_path):
+                    for path in self._pex.mount(pex_path):
                         self._display_line(f"added sys.path entry {path}\n")
             except Exception:
                 try:

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -45,11 +45,11 @@ def test_pex_load(pex: Pex, tmpdir: Path) -> None:
     not other_interpreters(), reason="Test requires at least one other interpreter to run."
 )
 def test_pex_load_correct_interpreter(pex: Pex, tmpdir: Path) -> None:
-    pex_file = tmpdir / "psutil.pex"
+    pex_file = tmpdir / "PyYAML.pex"
     subprocess.run(
         args=[
             str(pex.exe),
-            "psutil==5.7.3",
+            "PyYAML==5.4.1",
             "--interpreter-constraint",
             "CPython>=3.6,<4",
             "-o",
@@ -65,9 +65,9 @@ def test_pex_load_correct_interpreter(pex: Pex, tmpdir: Path) -> None:
             dedent(
                 f"""\
                 try:
-                    import psutil
+                    import yaml
                     raise AssertionError(
-                        "Should not have been able to import psutil before loading {pex_file}."
+                        "Should not have been able to import yaml before loading {pex_file}."
                     )
                 except ImportError:
                     # Expected.
@@ -75,7 +75,7 @@ def test_pex_load_correct_interpreter(pex: Pex, tmpdir: Path) -> None:
 
                 %load_ext pants_jupyter_plugin
                 %pex_load {pex_file}
-                import psutil
+                import yaml
                 """
             ),
         ],
@@ -87,12 +87,12 @@ def test_pex_load_correct_interpreter(pex: Pex, tmpdir: Path) -> None:
     not other_interpreters(), reason="Test requires at least one other interpreter to run."
 )
 def test_pex_load_correct_interpreter_not_available(pex: Pex, tmpdir: Path) -> None:
-    pex_file = tmpdir / "psutil.pex"
+    pex_file = tmpdir / "PyYAML.pex"
     current_interpreter_version = ".".join(map(str, sys.version_info[:3]))
     subprocess.run(
         args=[
             str(pex.exe),
-            "psutil==5.7.3",
+            "PyYAML==5.4.1",
             "--interpreter-constraint",
             f"CPython>=3.6,<4,!={current_interpreter_version}",
             "-o",
@@ -110,7 +110,7 @@ def test_pex_load_correct_interpreter_not_available(pex: Pex, tmpdir: Path) -> N
                 f"""\
                 %load_ext pants_jupyter_plugin
                 %pex_load {pex_file}
-                import psutil
+                import yaml
                 """
             ),
         ],

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -51,7 +51,7 @@ def test_pex_load_correct_interpreter(pex: Pex, tmpdir: Path) -> None:
             str(pex.exe),
             "psutil==5.7.3",
             "--interpreter-constraint",
-            "CPython>=2.7,<4",
+            "CPython>=3.6,<4",
             "-o",
             str(pex_file),
         ],
@@ -94,7 +94,7 @@ def test_pex_load_correct_interpreter_not_available(pex: Pex, tmpdir: Path) -> N
             str(pex.exe),
             "psutil==5.7.3",
             "--interpreter-constraint",
-            f"CPython>=2.7,<4,!={current_interpreter_version}",
+            f"CPython>=3.6,<4,!={current_interpreter_version}",
             "-o",
             str(pex_file),
         ],
@@ -124,7 +124,7 @@ def test_pex_load_correct_interpreter_not_available(pex: Pex, tmpdir: Path) -> N
         f"{current_interpreter_version}."
     )
     lines.remove(f"This is not compatible with the PEX at {pex_file}.")
-    lines.remove(f"It has interpreter constraints CPython>=2.7,<4,!={current_interpreter_version}.")
+    lines.remove(f"It has interpreter constraints CPython>=3.6,<4,!={current_interpreter_version}.")
 
     count = -1
     for line in list(lines):

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -15,7 +15,7 @@ from pants_jupyter_plugin.pex import Pex
 
 def test_pex_load(pex: Pex, tmpdir: Path) -> None:
     pex_file = tmpdir / "colors.pex"
-    subprocess.run([str(pex.exe), "ansicolors==1.1.8", "-o", pex_file], check=True)
+    subprocess.run([str(pex.exe), "ansicolors==1.1.8", "-o", str(pex_file)], check=True)
     subprocess.run(
         args=[
             "ipython",
@@ -53,7 +53,7 @@ def test_pex_load_correct_interpreter(pex: Pex, tmpdir: Path) -> None:
             "--interpreter-constraint",
             "CPython>=2.7,<4",
             "-o",
-            pex_file,
+            str(pex_file),
         ],
         check=True,
     )
@@ -96,7 +96,7 @@ def test_pex_load_correct_interpreter_not_available(pex: Pex, tmpdir: Path) -> N
             "--interpreter-constraint",
             f"CPython>=2.7,<4,!={current_interpreter_version}",
             "-o",
-            pex_file,
+            str(pex_file),
         ],
         check=True,
     )


### PR DESCRIPTION
We now ensure PEX files we create are compatible with the current
interpreter and we also ensure PEX files we're asked to load are as
well; failing with an informative error if not.

Fixes #10