### PR TITLE
Relax version pins.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ author-email = "pantsbuild@gmail.com"
 home-page = "https://github.com/pantsbuild/pants-jupyter-plugin"
 description-file = "README.md"
 classifiers = [
-  "Development Status :: 2 - Pre-Alpha",
+  "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
   "License :: OSI Approved :: Apache Software License",
@@ -25,13 +25,13 @@ classifiers = [
 requires-python = ">=3.6,<3.10"
 requires = [
   "dataclasses==0.8; python_version == '3.6'",
-  "filelock==3.0.12",
-  "ipython==7.16.1",
-  "ipywidgets==7.6.3",
-  "nest_asyncio==1.5.1",
-  "requests==2.25.1",
-  "twitter.common.contextutil==0.3.11",
-  "xdg==5.0.1",
+  "filelock>=3.0",
+  "ipython>=5.5.0,<8.0",
+  "ipywidgets>=7.0.0,<8.0",
+  "nest_asyncio~=1.5.1",
+  "requests>=2.22.0",
+  "twitter.common.contextutil~=0.3.11",
+  "xdg>=5.0.0,<6.0",
 ]
 
 [tool.flit.sdist]


### PR DESCRIPTION
Resolves example notebook breakage on Colab:

```
Processing ./pants-jupyter-plugin.zip
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied: requests>=2.22.0 in /usr/local/lib/python3.7/dist-packages (from pants-jupyter-plugin==0.0.1) (2.23.0)
Requirement already satisfied: nest_asyncio~=1.5.1 in /usr/local/lib/python3.7/dist-packages (from pants-jupyter-plugin==0.0.1) (1.5.1)
Collecting twitter.common.contextutil~=0.3.11
  Downloading https://files.pythonhosted.org/packages/e5/59/2ef7d20968abbad9e553d8791fdbeefb734eaa986a8a921e33faa368598e/twitter.common.contextutil-0.3.11.tar.gz
Requirement already satisfied: ipywidgets<8.0,>=7.0.0 in /usr/local/lib/python3.7/dist-packages (from pants-jupyter-plugin==0.0.1) (7.6.3)
Requirement already satisfied: ipython<8.0,>=5.5.0 in /usr/local/lib/python3.7/dist-packages (from pants-jupyter-plugin==0.0.1) (5.5.0)
Requirement already satisfied: filelock>=3.0 in /usr/local/lib/python3.7/dist-packages (from pants-jupyter-plugin==0.0.1) (3.0.12)
Collecting xdg<6.0,>=5.0.0
  Downloading https://files.pythonhosted.org/packages/be/eb/a4669d56ce4934d88a163e4b0d3cbc96606c073100bd6031f7972679877b/xdg-5.0.1-py3-none-any.whl
Requirement already satisfied: idna<3,>=2.5 in /usr/local/lib/python3.7/dist-packages (from requests>=2.22.0->pants-jupyter-plugin==0.0.1) (2.10)
Requirement already satisfied: chardet<4,>=3.0.2 in /usr/local/lib/python3.7/dist-packages (from requests>=2.22.0->pants-jupyter-plugin==0.0.1) (3.0.4)
Requirement already satisfied: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /usr/local/lib/python3.7/dist-packages (from requests>=2.22.0->pants-jupyter-plugin==0.0.1) (1.24.3)
Requirement already satisfied: certifi>=2017.4.17 in /usr/local/lib/python3.7/dist-packages (from requests>=2.22.0->pants-jupyter-plugin==0.0.1) (2020.12.5)
Collecting twitter.common.dirutil==0.3.11
  Downloading https://files.pythonhosted.org/packages/05/d0/6e76770b4c0251ed86c736563bf926696f2a0692a607f3346cbea3e45bbc/twitter.common.dirutil-0.3.11.tar.gz
Requirement already satisfied: jupyterlab-widgets>=1.0.0; python_version >= "3.6" in /usr/local/lib/python3.7/dist-packages (from ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (1.0.0)
Requirement already satisfied: traitlets>=4.3.1 in /usr/local/lib/python3.7/dist-packages (from ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (5.0.5)
Requirement already satisfied: ipykernel>=4.5.1 in /usr/local/lib/python3.7/dist-packages (from ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (4.10.1)
Requirement already satisfied: widgetsnbextension~=3.5.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (3.5.1)
Requirement already satisfied: nbformat>=4.2.0 in /usr/local/lib/python3.7/dist-packages (from ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (5.1.2)
Requirement already satisfied: prompt-toolkit<2.0.0,>=1.0.4 in /usr/local/lib/python3.7/dist-packages (from ipython<8.0,>=5.5.0->pants-jupyter-plugin==0.0.1) (1.0.18)
Requirement already satisfied: decorator in /usr/local/lib/python3.7/dist-packages (from ipython<8.0,>=5.5.0->pants-jupyter-plugin==0.0.1) (4.4.2)
Requirement already satisfied: pexpect; sys_platform != "win32" in /usr/local/lib/python3.7/dist-packages (from ipython<8.0,>=5.5.0->pants-jupyter-plugin==0.0.1) (4.8.0)
Requirement already satisfied: pygments in /usr/local/lib/python3.7/dist-packages (from ipython<8.0,>=5.5.0->pants-jupyter-plugin==0.0.1) (2.6.1)
Requirement already satisfied: setuptools>=18.5 in /usr/local/lib/python3.7/dist-packages (from ipython<8.0,>=5.5.0->pants-jupyter-plugin==0.0.1) (54.0.0)
Requirement already satisfied: pickleshare in /usr/local/lib/python3.7/dist-packages (from ipython<8.0,>=5.5.0->pants-jupyter-plugin==0.0.1) (0.7.5)
Requirement already satisfied: simplegeneric>0.8 in /usr/local/lib/python3.7/dist-packages (from ipython<8.0,>=5.5.0->pants-jupyter-plugin==0.0.1) (0.8.1)
Collecting twitter.common.lang==0.3.11
  Downloading https://files.pythonhosted.org/packages/57/29/37c4cbd8f1707d3f7111ea9ad01988d93439b09ecf794d71d979becad000/twitter.common.lang-0.3.11.tar.gz
Requirement already satisfied: ipython-genutils in /usr/local/lib/python3.7/dist-packages (from traitlets>=4.3.1->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (0.2.0)
Requirement already satisfied: jupyter-client in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (5.3.5)
Requirement already satisfied: tornado>=4.0 in /usr/local/lib/python3.7/dist-packages (from ipykernel>=4.5.1->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (5.1.1)
Requirement already satisfied: notebook>=4.4.1 in /usr/local/lib/python3.7/dist-packages (from widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (5.3.1)
Requirement already satisfied: jsonschema!=2.5.0,>=2.4 in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (2.6.0)
Requirement already satisfied: jupyter-core in /usr/local/lib/python3.7/dist-packages (from nbformat>=4.2.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (4.7.1)
Requirement already satisfied: wcwidth in /usr/local/lib/python3.7/dist-packages (from prompt-toolkit<2.0.0,>=1.0.4->ipython<8.0,>=5.5.0->pants-jupyter-plugin==0.0.1) (0.2.5)
Requirement already satisfied: six>=1.9.0 in /usr/local/lib/python3.7/dist-packages (from prompt-toolkit<2.0.0,>=1.0.4->ipython<8.0,>=5.5.0->pants-jupyter-plugin==0.0.1) (1.15.0)
Requirement already satisfied: ptyprocess>=0.5 in /usr/local/lib/python3.7/dist-packages (from pexpect; sys_platform != "win32"->ipython<8.0,>=5.5.0->pants-jupyter-plugin==0.0.1) (0.7.0)
Requirement already satisfied: python-dateutil>=2.1 in /usr/local/lib/python3.7/dist-packages (from jupyter-client->ipykernel>=4.5.1->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (2.8.1)
Requirement already satisfied: pyzmq>=13 in /usr/local/lib/python3.7/dist-packages (from jupyter-client->ipykernel>=4.5.1->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (22.0.3)
Requirement already satisfied: terminado>=0.8.1 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (0.9.2)
Requirement already satisfied: jinja2 in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (2.11.3)
Requirement already satisfied: Send2Trash in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (1.5.0)
Requirement already satisfied: nbconvert in /usr/local/lib/python3.7/dist-packages (from notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (5.6.1)
Requirement already satisfied: MarkupSafe>=0.23 in /usr/local/lib/python3.7/dist-packages (from jinja2->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (1.1.1)
Requirement already satisfied: defusedxml in /usr/local/lib/python3.7/dist-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (0.6.0)
Requirement already satisfied: mistune<2,>=0.8.1 in /usr/local/lib/python3.7/dist-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (0.8.4)
Requirement already satisfied: testpath in /usr/local/lib/python3.7/dist-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (0.4.4)
Requirement already satisfied: entrypoints>=0.2.2 in /usr/local/lib/python3.7/dist-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (0.3)
Requirement already satisfied: bleach in /usr/local/lib/python3.7/dist-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (3.3.0)
Requirement already satisfied: pandocfilters>=1.4.1 in /usr/local/lib/python3.7/dist-packages (from nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (1.4.3)
Requirement already satisfied: webencodings in /usr/local/lib/python3.7/dist-packages (from bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (0.5.1)
Requirement already satisfied: packaging in /usr/local/lib/python3.7/dist-packages (from bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (20.9)
Requirement already satisfied: pyparsing>=2.0.2 in /usr/local/lib/python3.7/dist-packages (from packaging->bleach->nbconvert->notebook>=4.4.1->widgetsnbextension~=3.5.0->ipywidgets<8.0,>=7.0.0->pants-jupyter-plugin==0.0.1) (2.4.7)
Building wheels for collected packages: pants-jupyter-plugin
  Building wheel for pants-jupyter-plugin (PEP 517) ... done
  Created wheel for pants-jupyter-plugin: filename=pants_jupyter_plugin-0.0.1-cp37-none-any.whl size=16845 sha256=b7caf4f34534ddb390b065d03f5885d714deec12052302bb730213e3eb35ddd0
  Stored in directory: /root/.cache/pip/wheels/16/04/1e/43d5a062dfcdfc6105d68aa47108c448a729c735e4f73392f4
Successfully built pants-jupyter-plugin
Building wheels for collected packages: twitter.common.contextutil, twitter.common.dirutil, twitter.common.lang
  Building wheel for twitter.common.contextutil (setup.py) ... done
  Created wheel for twitter.common.contextutil: filename=twitter.common.contextutil-0.3.11-cp37-none-any.whl size=4954 sha256=6f0df2ddbcbc8f46f9f3dd03eb95906c76ca7f4abbc4d083ca0244a87b679bcb
  Stored in directory: /root/.cache/pip/wheels/58/46/78/487afb7b32bc4cce153fc7b60387746cd88ec5938da241b008
  Building wheel for twitter.common.dirutil (setup.py) ... done
  Created wheel for twitter.common.dirutil: filename=twitter.common.dirutil-0.3.11-cp37-none-any.whl size=12984 sha256=c2180a51f0649d7fdf2c08e8ff97e018ba51f276da4d83ac6750300e73976ae4
  Stored in directory: /root/.cache/pip/wheels/0f/5b/2f/47fe43b35d5e6a31e159f1ee8df6bc4b62f45d36536ba97964
  Building wheel for twitter.common.lang (setup.py) ... done
  Created wheel for twitter.common.lang: filename=twitter.common.lang-0.3.11-cp37-none-any.whl size=4870 sha256=c50c284eeb66336938b295c19c150d8786074f119d9f16bed6071738821baaaf
  Stored in directory: /root/.cache/pip/wheels/e2/75/c7/83df91a695f7d664ac32936d385900dc7d50b18812a82ec988
Successfully built twitter.common.contextutil twitter.common.dirutil twitter.common.lang
Installing collected packages: twitter.common.lang, twitter.common.dirutil, twitter.common.contextutil, xdg, pants-jupyter-plugin
Successfully installed pants-jupyter-plugin-0.0.1 twitter.common.contextutil-0.3.11 twitter.common.dirutil-0.3.11 twitter.common.lang-0.3.11 xdg-5.0.1
```