### PR TITLE
Fixup changelog order.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,15 @@
 # Release Notes
 
+## 0.0.3
+
++ [364bcbf](https://github.com/pantsbuild/pants-jupyter-plugin/commit/364bcbf) Relax version pins. (#29)
+
+## 0.0.2
+
++ [2cc2532](https://github.com/pantsbuild/pants-jupyter-plugin/commit/2cc2532) Ensure PEXes are compatible with `sys.executable`. (#25)
++ [c57afcd](https://github.com/pantsbuild/pants-jupyter-plugin/commit/c57afcd) Use the Pex CLI instead of the API. (#24)
+
 ## 0.0.1
 
 Initial public release.
 
-## 0.0.2
-
-+ 2cc2532 Ensure PEXes are compatible with `sys.executable`. (#25)
-+ c57afcd Use the Pex CLI instead of the API. (#24)
-
-## 0.0.3
-
-+ 364bcbf Relax version pins. (#29)

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -20,19 +20,32 @@ if pants_jupyter_plugin.__version__ in previous_tag:
     )
 
 changes = subprocess.check_output(
-    args=["git", "log", "--oneline", "--no-decorate", f"HEAD...{previous_tag}"],
+    args=[
+        "git",
+        "log",
+        "--pretty=format:+ [%h](https://github.com/pantsbuild/pants-jupyter-plugin/commit/%h) %s",
+        f"HEAD...{previous_tag}",
+    ],
 ).decode()
 
-with open("CHANGES.md", "a") as fp:
+with open("CHANGES.md") as fp:
+    # Discard title and blank line following it.
+    fp.readline()
+    fp.readline()
+
+    changelog = fp.read()
+
+with open("CHANGES.md", "w") as fp:
     fp.write(
         dedent(
             """\
+            # Release Notes
+
             ## {version}
 
             {changes}
+
+            {changelog}
             """
-        ).format(
-            version=pants_jupyter_plugin.__version__,
-            changes=os.linesep.join(f"+ {line}" for line in changes.splitlines()),
-        )
+        ).format(version=pants_jupyter_plugin.__version__, changes=changes, changelog=changelog)
     )


### PR DESCRIPTION
The changelog itself and the generation script are fixed to use
traditional most-recent first order and include commit links as well.