### PR TITLE
Break out an EnvManager class for adhoc path generation cases.

### DIFF
--- a/pants_jupyter_plugin/env.py
+++ b/pants_jupyter_plugin/env.py
@@ -3,10 +3,9 @@
 
 import os
 import sys
-from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Iterator, List, Mapping, Union
+from typing import Any, Iterable, Iterator, List, Mapping, Union
 
 
 def create(**env_vars: Any) -> Mapping[str, str]:

--- a/pants_jupyter_plugin/env.py
+++ b/pants_jupyter_plugin/env.py
@@ -6,7 +6,7 @@ import sys
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, List, Mapping, Iterator, Union
+from typing import Any, Iterator, List, Mapping, Union
 
 
 def create(**env_vars: Any) -> Mapping[str, str]:

--- a/pants_jupyter_plugin/env.py
+++ b/pants_jupyter_plugin/env.py
@@ -2,7 +2,11 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
 
 import os
-from typing import Any, Mapping
+import sys
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, List, Mapping, Iterator, Union
 
 
 def create(**env_vars: Any) -> Mapping[str, str]:
@@ -19,3 +23,36 @@ def create(**env_vars: Any) -> Mapping[str, str]:
         else:
             env.pop(name, None)
     return env
+
+
+@dataclass
+class EnvManager:
+    mounted: List[Path] = field(default_factory=list, hash=False)
+
+    def unmount(self) -> Iterator[Path]:
+        """Scrubs sys.path and sys.modules of any contents from previously mounted environments.
+
+        WARNING: This will irreversibly mutate sys.path and sys.modules each time it's called.
+        """
+        while self.mounted:
+            sys_path_entry = self.mounted.pop()
+            sys.path[:] = [
+                entry
+                for entry in sys.path
+                if entry and os.path.exists(entry) and not sys_path_entry.samefile(entry)
+            ]
+
+            for name, module in list(sys.modules.items()):
+                module_path = getattr(module, "__file__", None)
+                if module_path is not None:
+                    if sys_path_entry in Path(module_path).parents:
+                        del sys.modules[name]
+
+            yield sys_path_entry
+
+    def mount(self, path_parts: Iterable[Path]) -> Iterator[Path]:
+        """Mounts an iterable of path parts to sys.path."""
+        for path_entry in path_parts:
+            sys.path.append(str(path_entry))
+            self.mounted.append(path_entry)
+            yield path_entry

--- a/pants_jupyter_plugin/pex.py
+++ b/pants_jupyter_plugin/pex.py
@@ -96,7 +96,7 @@ class PexManager:
 
     def unmount(self) -> Iterator[Path]:
         for path_entry in self._env_mgr.unmount():
-            yield path_entry        
+            yield path_entry
 
     def mount(self, pex_to_mount: Path) -> Iterator[Path]:
         """Mounts the contents of the given PEX on the sys.path for importing."""


### PR DESCRIPTION
Creates a lower-level abstraction (`EnvManager`) for non-hermetic, managed sys.path generation cases. In our internal Bazel + pex rule implementation, for perf the default build product is an unzipped pex environment with constituent sys.path parts that comprise a bazel-managed compound python environment for a given target. This allows us to do PEX_PATH-like optimization mechanics (e.g. split 3rdparty vs source build isolation) at the cost of non-hermetic interfaces.
