### PR TITLE
Migrate from macos-10.15 to macos-11.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,13 +39,13 @@ jobs:
     strategy:
       matrix:
         python-version: [[3, 6], [3, 7], [3, 8], [3, 9], [3, 10]]
-        os: [ubuntu-20.04, macos-10.15]
+        os: [ubuntu-20.04, macos-11]
         exclude:
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 7]
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 8]
-          - os: macos-10.15
+          - os: macos-11
             python-version: [3, 9]
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,11 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+      # The Pants v1 tests require Python 3.6; so ensure we have it.
+      - name: Setup Python 3.6
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.6"
       - name: Setup Python ${{ join(matrix.python-version, '.') }}
         uses: actions/setup-python@v4
         with:


### PR DESCRIPTION
This gets ahead of the deprecation tracked here:
https://github.com/actions/runner-images/issues/5583