### PR TITLE
Allow `ipython` & `ipywidgets` v8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,8 @@ requires-python = ">=3.6,<3.11"
 requires = [
   "dataclasses==0.8; python_version == '3.6'",
   "filelock>=3.0",
-  "ipython>=5.5.0,<8.0",
-  "ipywidgets>=7.0.0,<8.0",
+  "ipython>=5.5.0,<9.0",
+  "ipywidgets>=7.0.0,<9.0",
   "nest_asyncio~=1.5.1",
   "requests>=2.22.0",
   "twitter.common.contextutil~=0.3.11",


### PR DESCRIPTION
Currently, pants-jupyter-plugin requires `ipython < 8.0`. This PR allows `ipython` & `ipywidgets` v8.